### PR TITLE
chore: mark *.ts as JavaScript in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ts linguist-language=JavaScript


### PR DESCRIPTION
reasons:
1. typescript is not a new language, it is a superset of javascript, just like flow, a type checking tool
2. users cannot find this project if they search github for javascript projects