### PR TITLE
chore(type-check): disallow features emiting cross-file information

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
+    "isolatedModules": true, // Disallow features that require cross-file information for emit.
     "lib": ["ES2017", "dom"],
     "noEmit": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
see the Caveats section of this post
https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/