### PR TITLE
chore: require npm >= 6.6 to avoid keep updating package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "license": "MIT",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=8.9",
+    "npm": ">=6.6"
   },
   "scripts": {
     "build:watch": "rollup -c -w",


### PR DESCRIPTION
this doesn't affect ci
because this checking only run if user set `npm config set engine-strict true`, which we should add this config