### PR TITLE
chore: use js inline sourcemap & remove css sourcemap

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ export default appNames.map((appName) => ({
   output: {
     file: `dist/${appName}.js`,
     format: 'iife',
-    sourcemap: !isProd
+    sourcemap: isProd ? false : 'inline'
   },
   plugins: [
     babel({
@@ -40,7 +40,7 @@ export default appNames.map((appName) => ({
     svelte({
       css: (css) => {
         if (css.code) {
-          css.write(`dist/${appName}.css`, !isProd)
+          css.write(`dist/${appName}.css`, false)
         }
       },
       preprocess: {


### PR DESCRIPTION
fix for https://developer.mozilla.org/en-US/docs/Tools/Debugger/Source_map_errors#NetworkError_when_attempting_to_fetch_resource

css source map is removed because it is useless and no inline alternative from svelte