### PR TITLE
feat: add container service methods

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,5 @@
 extends:
   - 'eslint-config-foray1010/typescript'
   - 'eslint-config-foray1010/rules/frontend'
+globals:
+  browser: false

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,29 @@
 import '@babel/polyfill'
 
-console.log('running on background')
+import {clearDomainCookies, setupContainer} from './services/container'
+
+// TODO: testing, can remove
+const TWITTER_DOMAINS = [
+  'twitter.com',
+  'www.twitter.com',
+  't.co',
+  'twimg.com',
+  'mobile.twitter.com',
+  'm.twitter.com',
+  'api.twitter.com',
+  'abs.twimg.com',
+  'ton.twimg.com',
+  'pbs.twimg.com',
+  'tweetdeck.twitter.com'
+]
+
+async function init() {
+  const cookieStoreId = await setupContainer({
+    name: 'Testing Twitter'
+  })
+  await clearDomainCookies(cookieStoreId, {
+    domains: TWITTER_DOMAINS
+  })
+}
+
+init().catch((err) => console.error(err))

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,14 @@
     "browser_style": true,
     "default_popup": "popup.html"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "@web-containers",
+      "strict_min_version": "53.0"
+    }
+  },
   "manifest_version": 2,
+  "permissions": ["http://*/*", "https://*/*", "contextualIdentities", "cookies"],
   "name": "web-containers",
   "version": "0.1"
 }

--- a/src/services/container.ts
+++ b/src/services/container.ts
@@ -1,0 +1,78 @@
+const DEFAULT_CONTAINER_COLOR = 'blue'
+const DEFAULT_CONTAINER_ICON = 'fingerprint'
+
+/**
+ * Upsert a container and retrieve the cookieStoreId
+ */
+async function setupContainer(option: {
+  name: string
+  color?: string
+  icon?: string
+}): Promise<string> {
+  const {name, color = DEFAULT_CONTAINER_COLOR, icon = DEFAULT_CONTAINER_ICON} = option
+  const contexts = await browser.contextualIdentities.query({
+    name
+  })
+
+  if (contexts.length > 0) {
+    return contexts[0].cookieStoreId
+  } else {
+    const context = await browser.contextualIdentities.create({
+      color,
+      icon,
+      name
+    })
+
+    return context.cookieStoreId
+  }
+}
+
+async function removeContainerCookiesByDomain(storeId: string, domain: string): Promise<void> {
+  // TODO: safer way to form the cookie url?
+  const cookieUrl = `https://${domain}/`
+
+  const cookies = await browser.cookies.getAll({
+    domain,
+    storeId
+  })
+
+  await Promise.all(
+    cookies.map((cookie) =>
+      browser.cookies.remove({
+        name: cookie.name,
+        url: cookieUrl,
+        storeId
+      }))
+  )
+}
+
+/**
+ * Remove domain cookies outside of designated container
+ */
+async function clearDomainCookies(
+  cookieStoreId: string,
+  containerOption: {
+    domains: Array<string>
+  }
+): Promise<void> {
+  const containers = await browser.contextualIdentities.query({})
+
+  const otherContainers = containers.filter(
+    (container) => container.cookieStoreId !== cookieStoreId
+  )
+
+  const removeAllDomainCookiesAsync = otherContainers.reduce<Array<Promise<void>>>(
+    (acc, container) => {
+      return [
+        ...acc,
+        ...containerOption.domains.map(async (domain) =>
+          removeContainerCookiesByDomain(container.cookieStoreId, domain))
+      ]
+    },
+    []
+  )
+
+  await Promise.all(removeAllDomainCookiesAsync)
+}
+
+export {setupContainer, clearDomainCookies}


### PR DESCRIPTION
- browser_specific_settings now set to a temp ID,
- strict_min_version set to 52, sync with `browsersync`
- add two container methods to 
  - add container
  - remove cookies in other containers
