### PR TITLE
feat: block webrequest on target domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,6 +1175,12 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/escape-string-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz",
+      "integrity": "sha512-KAruqgk9/340M4MYYasdBET+lyYN8KMXUuRKWO72f4SbmIMMFp9nnJiXUkJS0HC2SFe4x0R/fLozXIzqoUfSjA==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -4545,8 +4551,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "tsc"
   },
   "dependencies": {
-    "@babel/polyfill": "7.2.5"
+    "@babel/polyfill": "7.2.5",
+    "escape-string-regexp": "1.0.5"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",
@@ -26,6 +27,7 @@
     "@babel/preset-typescript": "7.1.0",
     "@commitlint/cli": "7.5.0",
     "@commitlint/config-conventional": "7.5.0",
+    "@types/escape-string-regexp": "1.0.0",
     "@types/firefox-webext-browser": "65.0.0",
     "chalk": "2.4.2",
     "cross-env": "5.2.0",

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,23 +1,36 @@
 import '@babel/polyfill'
 
 import {clearDomainCookies, setupContainer} from './services/container'
+import convertDomainToRegExp from './utils/convertDomainToRegExp'
 
 // TODO: testing, can remove
-const TWITTER_DOMAINS = [
-  'twitter.com',
-  'www.twitter.com',
-  't.co',
-  'twimg.com',
-  'mobile.twitter.com',
-  'm.twitter.com',
-  'api.twitter.com',
-  'abs.twimg.com',
-  'ton.twimg.com',
-  'pbs.twimg.com',
-  'tweetdeck.twitter.com'
-]
+const TWITTER_DOMAINS = ['*.t.co', '*.twimg.com', '*.twitter.com']
+const TWITTER_DOMAIN_REGEXPS = TWITTER_DOMAINS.map(convertDomainToRegExp)
+console.debug('TWITTER_DOMAIN_REGEXPS', TWITTER_DOMAIN_REGEXPS)
 
-async function init() {
+browser.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    console.debug('onBeforeRequest request', {
+      'details.url': details.url,
+      'new URL(details.url).hostname': new URL(details.url).hostname
+    })
+
+    const response = {
+      cancel: TWITTER_DOMAIN_REGEXPS.some((regexp) => {
+        return regexp.test(new URL(details.url).hostname)
+      })
+    }
+    console.debug('onBeforeRequest response', response)
+    return response
+  },
+  {
+    types: ['main_frame'],
+    urls: ['http://*/*', 'https://*/*']
+  },
+  ['blocking']
+)
+
+async function init(): Promise<void> {
   const cookieStoreId = await setupContainer({
     name: 'Testing Twitter'
   })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,14 @@
     }
   },
   "manifest_version": 2,
-  "permissions": ["http://*/*", "https://*/*", "contextualIdentities", "cookies"],
   "name": "web-containers",
+  "permissions": [
+    "http://*/*",
+    "https://*/*",
+    "contextualIdentities",
+    "cookies",
+    "webRequest",
+    "webRequestBlocking"
+  ],
   "version": "0.1"
 }

--- a/src/utils/convertDomainToRegExp.ts
+++ b/src/utils/convertDomainToRegExp.ts
@@ -1,0 +1,5 @@
+import escapeStringRegexp from 'escape-string-regexp'
+
+export default (domain: string): RegExp => {
+  return new RegExp('^' + escapeStringRegexp(domain).replace(/^\\\*\\\./, '(.+\\.)?') + '$', 'i')
+}


### PR DESCRIPTION
will merge with https://github.com/foray1010/web-containers/pull/49 after that pr is merged
will add babel plugin to remove console.debug
will create another pr for unit test on convertDomainToRegExp