### PR TITLE
chore: bump strict_min_version to 57 for firefox android support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-Firefox > 52
+Firefox >= 57

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "@web-containers",
-      "strict_min_version": "53.0"
+      "strict_min_version": "57.0"
     }
   },
   "manifest_version": 2,


### PR DESCRIPTION
<img width="988" alt="screen shot 2019-02-23 at 9 36 02 am" src="https://user-images.githubusercontent.com/3212221/53279868-02f11500-370c-11e9-8ea3-460c6e614029.png">
